### PR TITLE
Relax yatra version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
 
   "license": "MIT",
   "dependencies": {
-    "yatra": "~1.0.0"
+    "yatra": "^1.0.0"
   }
 }


### PR DESCRIPTION
Adapter should use version as customer use. Current yatra version is 1.2.0 but it's impossible to use it with adapter.
